### PR TITLE
Replace expired Atla links with Wayback Machine URLs

### DIFF
--- a/content/presentations/_index.md
+++ b/content/presentations/_index.md
@@ -15,10 +15,10 @@ comment = false
 
 ### External write-ups
 At Atla:
-- [How to build a general purpose LLM evaluator: Lessons from our literature review](https://www.atla-ai.com/post/literature-review)
+- [How to build a general purpose LLM evaluator: Lessons from our literature review](https://web.archive.org/web/20260206183359/https://www.atla-ai.com/post/literature-review)
 - [Training an LLM-as-a-Judge with Synthetic Data
-](https://www.atla-ai.com/post/training-an-llm-as-a-judge-with-synthetic-data)
-- [Selecting a training objective for an AI evaluator (SFT vs. DPO vs. RPO)](https://www.atla-ai.com/post/selecting-a-training-objective-for-an-ai-evaluator)
+](https://web.archive.org/web/20260206185628/https://www.atla-ai.com/post/training-an-llm-as-a-judge-with-synthetic-data)
+- [Selecting a training objective for an AI evaluator (SFT vs. DPO vs. RPO)](https://web.archive.org/web/20260206195159/https://www.atla-ai.com/post/selecting-a-training-objective-for-an-ai-evaluator)
 
 ### Presentations
 {{ collection(file="items.toml") }}


### PR DESCRIPTION
The Atla website (atla-ai.com) has been shut down, so the three blog post links in the "Other work" page are broken. This PR replaces them with their Wayback Machine archived versions:

- Literature review → archived Feb 6, 2026
- Training an LLM-as-a-Judge with Synthetic Data → archived Feb 6, 2026
- Selecting a training objective for an AI evaluator → archived Feb 6, 2026

---

**Created by Maestro on behalf of Andrei Alexandru**

[View Session](https://dev.igent.ai/thread/53bdb776-9eae-4e21-b5f5-c21ec502b691)